### PR TITLE
Bump engine.io and socket.io

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,12 +39,6 @@
             "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
             "dev": true
         },
-        "@types/component-emitter": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-            "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
-            "dev": true
-        },
         "@types/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -409,12 +403,6 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
-        "component-emitter": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -649,24 +637,6 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
             "dev": true
-        },
-        "engine.io": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
-            "integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
-            "dev": true,
-            "requires": {
-                "@types/cookie": "^0.4.1",
-                "@types/cors": "^2.8.12",
-                "@types/node": ">=10.0.0",
-                "accepts": "~1.3.4",
-                "base64id": "2.0.0",
-                "cookie": "~0.4.1",
-                "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.3",
-                "ws": "~8.2.3"
-            }
         },
         "engine.io-client": {
             "version": "6.1.1",
@@ -1803,37 +1773,60 @@
             }
         },
         "socket.io": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-            "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
+            "integrity": "sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
                 "debug": "~4.3.2",
-                "engine.io": "~6.1.0",
-                "socket.io-adapter": "~2.3.3",
-                "socket.io-parser": "~4.0.4"
+                "engine.io": "~6.2.0",
+                "socket.io-adapter": "~2.4.0",
+                "socket.io-parser": "~4.2.0"
             },
             "dependencies": {
-                "socket.io-parser": {
-                    "version": "4.0.4",
-                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-                    "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+                "@socket.io/component-emitter": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+                    "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+                    "dev": true
+                },
+                "engine.io": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+                    "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
                     "dev": true,
                     "requires": {
-                        "@types/component-emitter": "^1.2.10",
-                        "component-emitter": "~1.3.0",
+                        "@types/cookie": "^0.4.1",
+                        "@types/cors": "^2.8.12",
+                        "@types/node": ">=10.0.0",
+                        "accepts": "~1.3.4",
+                        "base64id": "2.0.0",
+                        "cookie": "~0.4.1",
+                        "cors": "~2.8.5",
+                        "debug": "~4.3.1",
+                        "engine.io-parser": "~5.0.3",
+                        "ws": "~8.2.3"
+                    }
+                },
+                "socket.io-adapter": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+                    "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
+                    "dev": true
+                },
+                "socket.io-parser": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+                    "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+                    "dev": true,
+                    "requires": {
+                        "@socket.io/component-emitter": "~3.1.0",
                         "debug": "~4.3.1"
                     }
                 }
             }
-        },
-        "socket.io-adapter": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-            "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
-            "dev": true
         },
         "socket.io-client": {
             "version": "4.4.1",


### PR DESCRIPTION
Bumps [engine.io](https://github.com/socketio/engine.io) and [socket.io](https://github.com/socketio/socket.io). These dependencies needed to be updated together.

Updates `engine.io` from 6.1.3 to 6.2.1
- [Release notes](https://github.com/socketio/engine.io/releases)
- [Changelog](https://github.com/socketio/engine.io/blob/main/CHANGELOG.md)
- [Commits](https://github.com/socketio/engine.io/compare/6.1.3...6.2.1)

Updates `socket.io` from 4.4.1 to 4.5.3
- [Release notes](https://github.com/socketio/socket.io/releases)
- [Changelog](https://github.com/socketio/socket.io/blob/main/CHANGELOG.md)
- [Commits](https://github.com/socketio/socket.io/compare/4.4.1...4.5.3)

---
updated-dependencies:
- dependency-name: engine.io dependency-type: indirect
- dependency-name: socket.io dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>